### PR TITLE
解决win的头文件在vs 警告等级为w4, 警告视为错误编译条件下的报错

### DIFF
--- a/src/common/base/StringView.hpp
+++ b/src/common/base/StringView.hpp
@@ -95,7 +95,7 @@ public:
     int compare(const UnsafeStringView& other) const;
     bool equal(const UnsafeStringView& other) const;
 
-    static constexpr size_t npos = -1;
+    static constexpr size_t npos = std::numeric_limits<size_t>::max();
     size_t find(const UnsafeStringView& other) const;
 
 #pragma mark - UnsafeStringView - Operations
@@ -129,6 +129,10 @@ public:
             return ColumnIsTextType<T>::asUnderlyingType(t);
         }
     };
+
+    template<typename T>
+    struct Convertible<T, std::enable_if_t<std::is_function<T>::value>>
+    : public std::false_type {};
 
     template<typename T, typename Enable = typename std::enable_if<Convertible<T>::value>::type>
     UnsafeStringView(const T& t)

--- a/src/common/base/StringView.hpp
+++ b/src/common/base/StringView.hpp
@@ -131,8 +131,7 @@ public:
     };
 
     template<typename T>
-    struct Convertible<T, std::enable_if_t<std::is_function<T>::value>>
-    : public std::false_type {};
+    struct Convertible<T, std::enable_if_t<std::is_function<T>::value>> : public std::false_type {};
 
     template<typename T, typename Enable = typename std::enable_if<Convertible<T>::value>::type>
     UnsafeStringView(const T& t)

--- a/src/common/core/config/Config.cpp
+++ b/src/common/core/config/Config.cpp
@@ -31,7 +31,7 @@ Config::~Config() = default;
 
 bool Config::uninvoke(InnerHandle *handle)
 {
-    WCDB_UNUSED(handle)
+    WCDB_UNUSED(handle);
     return true;
 }
 

--- a/src/common/core/fts/tokenizer/PinyinTokenizer.cpp
+++ b/src/common/core/fts/tokenizer/PinyinTokenizer.cpp
@@ -75,7 +75,7 @@ void PinyinTokenizer::loadInput(const char *pText, int nText, int flags)
 int PinyinTokenizer::nextToken(
 const char **ppToken, int *nToken, int *iStart, int *iEnd, int *tflags, int *iPosition)
 {
-    WCDB_UNUSED(iPosition)
+    WCDB_UNUSED(iPosition);
     if (m_flags & FTS5_TOKENIZE_QUERY || m_pinyinTokenArr.size() == m_pinyinTokenIndex) {
         while (true) {
             int ret = stepNextToken();

--- a/src/common/core/fts/tokenizer/TokenizerModule.cpp
+++ b/src/common/core/fts/tokenizer/TokenizerModule.cpp
@@ -37,7 +37,9 @@ namespace WCDB {
 
 #pragma mark - AbstractFTS5Tokenizer
 AbstractFTSTokenizer::AbstractFTSTokenizer(const char *const *azArg, int nArg, void *pCtx){
-    WCDB_UNUSED(pCtx) WCDB_UNUSED(azArg) WCDB_UNUSED(nArg)
+    WCDB_UNUSED(pCtx);
+    WCDB_UNUSED(azArg);
+    WCDB_UNUSED(nArg);
 }
 
 AbstractFTSTokenizer::~AbstractFTSTokenizer()

--- a/src/common/platform/WCTFileManager.cpp
+++ b/src/common/platform/WCTFileManager.cpp
@@ -41,15 +41,15 @@ StringView FileManager::getTemporaryDirectory()
 bool FileManager::setFileProtection(const WCDB::UnsafeStringView &path,
                                     WCDB::FileProtection fileProtection)
 {
-    WCDB_UNUSED(path)
-    WCDB_UNUSED(fileProtection)
+    WCDB_UNUSED(path);
+    WCDB_UNUSED(fileProtection);
     return true;
 }
 
 Optional<WCDB::FileProtection>
 FileManager::getFileProtection(const WCDB::UnsafeStringView &path)
 {
-    WCDB_UNUSED(path)
+    WCDB_UNUSED(path);
     return WCDB::FileProtection::None;
 }
 

--- a/src/common/platform/WCTOperationQueue.cpp
+++ b/src/common/platform/WCTOperationQueue.cpp
@@ -35,7 +35,7 @@ void *OperationQueueForMemory::registerNotificationWhenMemoryWarning()
 
 void OperationQueueForMemory::unregisterNotificationWhenMemoryWarning(void *observer)
 {
-    WCDB_UNUSED(observer)
+    WCDB_UNUSED(observer);
 }
 
 void OperationQueueForMemory::executeOperationWithAutoMemoryRelease(std::function<void(void)> operation)

--- a/src/common/repair/basic/Crawlable.cpp
+++ b/src/common/repair/basic/Crawlable.cpp
@@ -160,7 +160,7 @@ void Crawlable::safeCrawl(int rootpageno, std::set<int> &crawledInteriorPages, i
 
 void Crawlable::onCellCrawled(const Cell &cell)
 {
-    WCDB_UNUSED(cell)
+    WCDB_UNUSED(cell);
 }
 
 bool Crawlable::canCrawlPage(uint32_t pageno)
@@ -171,8 +171,8 @@ bool Crawlable::canCrawlPage(uint32_t pageno)
 
 bool Crawlable::willCrawlPage(const Page &page, int height)
 {
-    WCDB_UNUSED(page)
-    WCDB_UNUSED(height)
+    WCDB_UNUSED(page);
+    WCDB_UNUSED(height);
     return true;
 }
 

--- a/src/common/repair/crawl/SequenceCrawler.cpp
+++ b/src/common/repair/crawl/SequenceCrawler.cpp
@@ -87,7 +87,7 @@ void SequenceCrawler::onCrawlerError()
 
 bool SequenceCrawler::willCrawlPage(const Page &page, int height)
 {
-    WCDB_UNUSED(height)
+    WCDB_UNUSED(height);
     m_delegate->onSequencePageCrawled(page);
     return true;
 }

--- a/src/common/repair/factory/Factory.cpp
+++ b/src/common/repair/factory/Factory.cpp
@@ -172,7 +172,7 @@ bool Factory::removeDirectoryIfEmpty() const
     bool succeed = FileManager::enumerateDirectory(
     directory,
     [&canRemove](const UnsafeStringView &root, const UnsafeStringView &subpath, bool isDirectory) -> bool {
-        WCDB_UNUSED(root)
+        WCDB_UNUSED(root);
         if (subpath == restoreDirectoryName || !isDirectory) {
             return true;
         }

--- a/src/common/repair/factory/FactoryRetriever.cpp
+++ b/src/common/repair/factory/FactoryRetriever.cpp
@@ -385,7 +385,7 @@ bool FactoryRetriever::increaseProgress(const UnsafeStringView &databasePath,
                                         double progress,
                                         double increment)
 {
-    WCDB_UNUSED(progress)
+    WCDB_UNUSED(progress);
     if (useMaterial) {
         increment *= 0.5;
     }

--- a/src/common/repair/mechanic/Backup.cpp
+++ b/src/common/repair/mechanic/Backup.cpp
@@ -473,7 +473,7 @@ bool Backup::willCrawlPage(const Page &page, int height)
         markAsInterrupted();
         return false;
     }
-    WCDB_UNUSED(height)
+    WCDB_UNUSED(height);
     switch (page.getType()) {
     case Page::Type::InteriorTable:
         return true;
@@ -508,7 +508,7 @@ void Backup::onMasterPageCrawled(const Page &page)
 
 void Backup::onMasterCellCrawled(const Cell &cell, const MasterItem &master)
 {
-    WCDB_UNUSED(cell)
+    WCDB_UNUSED(cell);
     if (master.name == Syntax::sequenceTable) {
         m_material.info.seqTableRootPage = master.rootpage;
         SequenceCrawler crawler;
@@ -554,7 +554,7 @@ void Backup::onSequencePageCrawled(const Page &page)
 
 void Backup::onSequenceCellCrawled(const Cell &cell, const SequenceItem &sequence)
 {
-    WCDB_UNUSED(cell)
+    WCDB_UNUSED(cell);
     if (sequence.seq == 0) {
         return;
     }

--- a/src/common/repair/parse/PageBasedFileHandle.cpp
+++ b/src/common/repair/parse/PageBasedFileHandle.cpp
@@ -245,7 +245,7 @@ bool PageBasedFileHandle::Cache::shouldPurge() const
 
 void PageBasedFileHandle::Cache::willPurge(const Range& range, const MappedData& data)
 {
-    WCDB_UNUSED(range)
+    WCDB_UNUSED(range);
     m_currentUsedMemery -= data.size();
 }
 

--- a/src/common/repair/parse/Pager.cpp
+++ b/src/common/repair/parse/Pager.cpp
@@ -394,7 +394,7 @@ bool Pager::Cache::shouldPurge() const
 
 void Pager::Cache::willPurge(const uint32_t& pageNum, const UnsafeData& data)
 {
-    WCDB_UNUSED(pageNum)
+    WCDB_UNUSED(pageNum);
     m_currentUsedMemery -= data.size();
 }
 

--- a/src/common/utility/Macro.h
+++ b/src/common/utility/Macro.h
@@ -116,7 +116,7 @@
 #if !defined(_WIN32)
 #define WCDB_UNUSED(variable) _Pragma(WCDB_STRINGIFY(unused(variable)))
 #else
-#define WCDB_UNUSED(variable)
+#define WCDB_UNUSED(variable) (void)(variable)
 #endif
 
 #ifdef __clang__

--- a/src/common/winq/extension/ColumnType.hpp
+++ b/src/common/winq/extension/ColumnType.hpp
@@ -260,6 +260,9 @@ public:
                         const ColumnTypeInfo<ColumnType::Text>::UnderlyingType &t);
 };
 
+template<typename T>
+struct ColumnIsTextType<T, std::enable_if_t<std::is_function<T>::value>> : public std::false_type {};
+
 //BLOB
 template<>
 struct WCDB_API ColumnIsBLOBType<std::vector<unsigned char>> : public std::true_type {

--- a/src/common/winq/extension/ConvertibleImplementation.hpp
+++ b/src/common/winq/extension/ConvertibleImplementation.hpp
@@ -40,7 +40,7 @@ class LiteralValueConvertible<std::nullptr_t> final : public std::true_type {
 public:
     static LiteralValue asLiteralValue(const std::nullptr_t& t)
     {
-        WCDB_UNUSED(t)
+        WCDB_UNUSED(t);
         return nullptr;
     }
 };

--- a/src/cpp/Operation/StatementOperation.hpp
+++ b/src/cpp/Operation/StatementOperation.hpp
@@ -344,12 +344,13 @@ public:
     OptionalValueArray<ObjectType> extractAllObjects(const ResultFields& resultFields)
     {
         OptionalValueArray<ObjectType> result;
-        bool succeed = false;
-        while ((succeed = step()) && !done()) {
+        bool succeed = step();
+        while (succeed && !done()) {
             if (!result.succeed()) {
                 result = ValueArray<ObjectType>();
             }
             result->push_back(extractOneObject<ObjectType>(resultFields));
+            succeed = step();
         }
         if (!succeed) {
             return NullOpt;

--- a/src/cpp/chaincall/Insert.hpp
+++ b/src/cpp/chaincall/Insert.hpp
@@ -202,7 +202,8 @@ private:
             size_t count = getObjectCount();
             for (size_t i = 0; i < count; i++) {
                 const ObjectType& obj = getObjectAtIndex(i);
-                if (!(succeed = stepOneObject(obj, autoIncrementsOfDefinitions))) {
+                succeed = stepOneObject(obj, autoIncrementsOfDefinitions);
+                if (!(succeed)) {
                     break;
                 }
             }
@@ -261,7 +262,6 @@ private:
             return *((*m_objSharedPtrArr)[index]);
         default:
             abort();
-            return *m_obj;
         }
     }
 


### PR DESCRIPTION
解决win的头文件在vs 警告等级为w4, 警告视为错误编译条件下的报错